### PR TITLE
Add sponsor descriptions

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,5 @@
+trailingComma: "all"
+tabWidth: 2
+semi: false
+singleQuote: false
+proseWrap: "never"

--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -38,7 +38,9 @@
   url: https://www.thestar.com
   logo: Toronto-Star-Logo.svg
   level: presenting_sponsor
-  description: coming soon.
+  description: |
+    <p>The Toronto Star is Canada’s largest local daily newspaper, reaching more than 7.7 million readers across its print and digital platforms. With a legacy as the “paper for the people” and founding principles that guide its newsroom to this day, the Star continues to uphold the highest standards of journalistic integrity and social responsibility.</p>
+    <p>Toronto Star’s award-winning journalism often focuses public attention on injustices and the reforms designed to correct them. The Star is proud to be the news organization people turn to when they want a sense of community — where they are seen and heard — and when they want to see the scales balanced, wrongs righted and the powerful held to account.</p>
 
 - title: Bloom Works
   url: https://bloomworks.digital

--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -3,26 +3,36 @@
   logo: civictechtoronto.webp
   level: organizing_partner
   description: |
-    Civic Tech Toronto is a vibrant and diverse community of Torontonians engaged  in understanding and creating solutions for civic challenges through technology,  design, and other innovative means.
-    The organizing team for Civic Spark is predominantly formed from volunteers from Civic Tech Toronto.
+    <p>Civic Tech Toronto is a vibrant and diverse community engaged in understanding and creating solutions for civic challenges through technology, design, and other innovative means. Civic Spark has been made possible thanks to the commitment and leadership of many volunteers from the Civic Tech Toronto community.</p>    
+    <p>Since 2015, the Civic Tech Toronto community has come together at weekly meet-ups featuring a speaker as well as participant-organized breakout sessions to work on projects that use data, design, and technology to make Toronto better. Find out more and join us at an upcoming meet-up at <a href="https://civictech.ca/">civictech.ca</a></p>
 
 - title: Centre for Analytics & Artificial Intelligence Engineering (CARTE)
   url: https://carte.utoronto.ca
   logo: carte.png
   level: organizing_partner
-  description: coming soon.
+  description: |
+    <p>The Centre for Analytics & Artificial Intelligence Engineering (CARTE) is a hub for collaborations and partnerships in analytics and artificial intelligence at The University of Toronto's Faculty of Applied Science and Engineering. Their mission is to conduct state-of-the-art research while nurturing the next generation of engineering talent.</p>
+    <p>CARTE facilitates applied research in Artificial Intelligence (AI) with external partners, over 100 affiliated faculty members and students and also offers customizable AI and machine learning training to industry and academic partners.</p>
+
 
 - title: 1RG
   url: https://1rg.space
   logo: 1rg.svg
   level: organizing_partner
-  description: coming soon.
+  description: |
+    <p>1RG believes that the development of technology can and should be stewarded to support human agency, democracy, building richer and more vibrant communities, and the flourishing of all life.</p>
+    <p><a href="https://labs.1rg.space/">1RG Labs</a> develops good software for resilient futures. They provide expertise in engineering, data science, product development and security.</p>
+    <p><a href="https://1rg.space/">1RG Space</a> is an inclusive co-working and event space located in Toronto’s The Junction neighbourhood, built on a foundation of community. At 1RG Space, members can find a supportive environment to actively collaborate, grow, and learn together.</p>
+
 
 - title: Open Data – The City of Toronto
   url: https://open.toronto.ca
   logo: Toronto Lockup Transparent.png
   level: presenting_sponsor
-  description: coming soon.
+  description: |
+    <p>Since 2009, the City of Toronto Open Data team has published accessible, high-quality datasets that support transparency, innovation, and public engagement through the City’s Open Data portal. This service of the City’s Technology Services division helps residents, businesses, and researchers use city data to inform decisions, build tools, and generate insights.</p>
+    <p>In addition to publicly sharing data from a variety of City divisions and agencies, the Open Data team also showcases citizens and companies that have used open data on their <a href="https://open.toronto.ca/gallery/">project gallery</a> and recognizes open data leaders in the City through their annual Open Data Awards.</p>
+
 
 - title: The Toronto Star
   url: https://www.thestar.com
@@ -34,10 +44,12 @@
   url: https://bloomworks.digital
   logo: bloom.svg
   level: major_sponsor
-  description: coming soon.
+  description: |
+    Bloom Works is a woman-owned public benefit company that helps government and other organizations serve people better with digital services and human-centred design.
 
 - title: Code for Canada
   url: https://codefor.ca
   logo: code-for-canada-logo.png
   level: supporting_sponsor
-  description: coming soon.
+  description: |
+    Code for Canada is a national non-profit that partners with governments and non-profits to help them independently deliver digital services that work for everyone. Through their work with over 50 government and non-profit partners to-date, their team uses digital skills for good, building capacity and creating better services.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,6 +2,7 @@
 layout: page
 title: About Us
 permalink: /about-us/
+redirect_from: /about-us
 ---
 
 <section>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -49,10 +49,13 @@ For us Civic Spark is a space to:
   <div class="partner-lists">
     {% for sponsor in site.data.sponsors %}
       {% if sponsor.level == "organizing_partner" %}
-        <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" title="{{ sponsor.title }}">
-          <img src="{{ site.baseurl }}/assets/images/sponsors/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="partner-logo">
-        </a>
-        {{ sponsor.description }}
+        <div class="organizing-partner">
+          <h4>{{ sponsor.title }}</h4>
+          <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" title="{{ sponsor.title }}">
+            <img src="{{ site.baseurl }}/assets/images/sponsors/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="partner-logo">
+          </a>
+          {{ sponsor.description }}
+        </div>
       {% endif %}
     {% endfor %}
   </div>

--- a/_pages/conference/schedule.md
+++ b/_pages/conference/schedule.md
@@ -3,6 +3,7 @@ layout: page
 title: Conference | Schedule
 description: Saturday, August 16, 2025 – Talks, sessions, and shared lessons from the field.
 permalink: /conference/schedule/
+redirect_from: /conference/schedule
 ---
 
 {% include conference-subnav.html%}

--- a/_pages/conference/speakers.md
+++ b/_pages/conference/speakers.md
@@ -3,6 +3,7 @@ layout: page
 title: Conference | Speakers
 description: Saturday, August 16, 2025 – Talks, sessions, and shared lessons from the field.
 permalink: /conference/speakers/
+redirect_from: /conference/speakers
 ---
 
 {% include conference-subnav.html%}

--- a/_pages/get-involved.md
+++ b/_pages/get-involved.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: Get Involved
-permalink: /get-involved
+permalink: /get-involved/
+redirect_from: /get-involved
 ---
 
 <section id="get-involved">

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -3,6 +3,7 @@ layout: home
 permalink: /
 redirect_from: /event-overview/
 ---
+
 <!-- 
 *
 * § Hero
@@ -10,17 +11,29 @@ redirect_from: /event-overview/
 -->
 <section class="hero">
   <article class="yellow-card-bg grid grid-blade">
-    <div class="image-area">
-      {% include svg-initial.svg %}
-    </div>
+    <div class="image-area">{% include svg-initial.svg %}</div>
     <div class="text-area">
       <h1>{% include logoform.html gray='true' %}</h1>
-      <p class="lead">​Share&nbsp;your&nbsp;story. Spark&nbsp;connection. Shape&nbsp;what’s&nbsp;next.</p>
-      <p>A two-day gathering for organizers, innovators, and community builders working toward a more equitable future of public life.</p>
+      <p class="lead">
+        ​Share&nbsp;your&nbsp;story. Spark&nbsp;connection.
+        Shape&nbsp;what’s&nbsp;next.
+      </p>
+      <p>
+        A two-day gathering for organizers, innovators, and community builders
+        working toward a more equitable future of public life.
+      </p>
       <p><small>August 16 – 17, 2025 in Toronto</small></p>
       <div class="cta-buttons">
-        <a role="button" class="contrast large" href="{{ site.data.links.registration }}" target="_blank">Register{% include ext-arrow.html %}</a>
-        <a role="button" class="contrast outline large" href="#event-overview" >Learn More</a>
+        <a
+          role="button"
+          class="contrast large"
+          href="{{ site.data.links.registration }}"
+          target="_blank"
+          >Register{% include ext-arrow.html %}</a
+        >
+        <a role="button" class="contrast outline large" href="#event-overview"
+          >Learn More</a
+        >
       </div>
     </div>
   </article>
@@ -33,15 +46,30 @@ redirect_from: /event-overview/
 <section id="event-overview">
   <div class="inset-section">
     <h2>Event Overview</h2>
-    <p class="lead">Civic Spark is a gathering for people who care about the future of public life.</p>
-    <p>We're bringing together organizers, technologists, public servants, mutual aid networks, researchers, designers, and community leaders from across North America.</p>
-    <p>This isn’t a pitch stage or a showcase. It’s a space to share real stories, challenge assumptions, and explore what works — and what doesn’t — when building for civic impact.</p>
-    <p>Whether you’re deep in the work or just getting started, you’re invited.</p>
+    <p class="lead">
+      Civic Spark is a gathering for people who care about the future of public
+      life.
+    </p>
+    <p>
+      We're bringing together organizers, technologists, public servants, mutual
+      aid networks, researchers, designers, and community leaders from across
+      North America.
+    </p>
+    <p>
+      This isn’t a pitch stage or a showcase. It’s a space to share real
+      stories, challenge assumptions, and explore what works — and what doesn’t
+      — when building for civic impact.
+    </p>
+    <p>
+      Whether you’re deep in the work or just getting started, you’re invited.
+    </p>
     <div class="cta-buttons">
-      <a role="button" class="contrast outline large" href="#why-now">Read More</a>
+      <a role="button" class="contrast outline large" href="#why-now"
+        >Read More</a
+      >
     </div>
   </div>
-  
+
   <!-- 
   *
   * § Overview: Why Now
@@ -49,20 +77,31 @@ redirect_from: /event-overview/
   -->
   <section id="why-now">
     <article class="magenta-card-bg grid grid-blade">
-      <div class="image-area">
-        {% include svg-respite.svg %}
-      </div>
+      <div class="image-area">{% include svg-respite.svg %}</div>
       <div class="text-area">
         <h3>Why Now</h3>
-        <p>Today's challenges are big, and the work can feel fragmented, exhausting, and unclear. <strong>Civic Spark is a chance to reconnect</strong> — with purpose, with people, and with the possibilities of what we can build together.</p>
+        <p>
+          Today's challenges are big, and the work can feel fragmented,
+          exhausting, and unclear.
+          <strong>Civic Spark is a chance to reconnect</strong> — with purpose,
+          with people, and with the possibilities of what we can build together.
+        </p>
         <ul>
           <li>Let’s share what’s working — and name what’s not.</li>
           <li>Let’s build across disciplines, roles, and lived experience.</li>
           <li>Let’s co-create what’s next.</li>
         </ul>
-        <p>We believe civic infrastructure can be resilient, public trust can be restored, and those most impacted can lead the way forward.</p>
+        <p>
+          We believe civic infrastructure can be resilient, public trust can be
+          restored, and those most impacted can lead the way forward.
+        </p>
         <div class="cta-buttons">
-          <a role="button" class="contrast outline large" href="#who-should-attend">Who is invited?</a>
+          <a
+            role="button"
+            class="contrast outline large"
+            href="#who-should-attend"
+            >Who is invited?</a
+          >
         </div>
       </div>
     </article>
@@ -74,26 +113,61 @@ redirect_from: /event-overview/
   -->
   <section id="who-should-attend">
     <article class="grid grid-blade reversed">
-      <div class="image-area">
-        {% include svg-bicycling.svg %}
-      </div>
+      <div class="image-area">{% include svg-bicycling.svg %}</div>
       <div class="text-area">
         <h3 class="colorized-orange">Who Should Attend</h3>
         <p class="lead colorized-orange">
-          If you're building something better — whether that’s a community, a project, a policy, or a platform — Civic Spark is for you.
+          If you're building something better — whether that’s a community, a
+          project, a policy, or a platform — Civic Spark is for you.
         </p>
         <p>Maybe you are (or want to be) a:</p>
         <ul>
-          <li><strong class="colorized-orange">public servant</strong> working collaboratively with communities.</li>
-          <li><strong class="colorized-orange">grassroots organizer</strong> exploring tech or data as a tool for justice.</li>
-          <li><strong class="colorized-orange">mutual aid volunteer</strong> making things work with what you’ve got.</li>
-          <li><strong class="colorized-orange">designer</strong>, <strong class="colorized-orange">technologist</strong>, or <strong class="colorized-orange">researcher</strong> committed to public interest work.</li>
-          <li><strong class="colorized-orange">student</strong> or <strong class="colorized-orange">newcomer</strong> looking to learn, connect, and contribute.</li>
+          <li>
+            <strong class="colorized-orange">public servant</strong> working
+            collaboratively with communities.
+          </li>
+          <li>
+            <strong class="colorized-orange">grassroots organizer</strong>
+            exploring tech or data as a tool for justice.
+          </li>
+          <li>
+            <strong class="colorized-orange">mutual aid volunteer</strong>
+            making things work with what you’ve got.
+          </li>
+          <li>
+            <strong class="colorized-orange">designer</strong>,
+            <strong class="colorized-orange">technologist</strong>, or
+            <strong class="colorized-orange">researcher</strong> committed to
+            public interest work.
+          </li>
+          <li>
+            <strong class="colorized-orange">student</strong> or
+            <strong class="colorized-orange">newcomer</strong> looking to learn,
+            connect, and contribute.
+          </li>
         </ul>
-        <p>Or someone who's <strong class="colorized-orange">just figuring out where you fit</strong> — but knows things need to change — whether formally or informally, institutionally or on the ground — you are invited.</p>
+        <p>
+          Or someone who's
+          <strong class="colorized-orange"
+            >just figuring out where you fit</strong
+          >
+          — but knows things need to change — whether formally or informally,
+          institutionally or on the ground — you are invited.
+        </p>
         <div class="cta-buttons">
-          <a role="button" class="secondary large" href="{{ site.data.links.registration }}" target="_blank">Register{% include ext-arrow.html %}</a>
-          <a role="button" class="secondary outline large" href="#what-to-expect">What can I expect?</a>
+          <a
+            role="button"
+            class="secondary large"
+            href="{{ site.data.links.registration }}"
+            target="_blank"
+            >Register{% include ext-arrow.html %}</a
+          >
+          <a
+            role="button"
+            class="secondary outline large"
+            href="#what-to-expect"
+            >What can I expect?</a
+          >
         </div>
       </div>
     </article>
@@ -105,7 +179,7 @@ redirect_from: /event-overview/
 *
 -->
 <section id="what-to-expect">
-  <H2>What to Expect</H2>
+  <h2>What to Expect</h2>
   <div class="grid grid-blade">
     <article>
       <div class="image-area colorized-magenta">
@@ -115,9 +189,21 @@ redirect_from: /event-overview/
         <h3 class="colorized-magenta">The Conference</h3>
         <p class="colorized-magenta">​​Saturday, Aug 16</p>
       </hgroup>
-      <p>A set schedule of <strong class="colorized-magenta">stories, sessions,</strong> and <strong class="colorized-magenta">shared lessons</strong> from people building community-powered tools, services, and networks. It’s a space to share what’s working, reflect on hard-won lessons, and explore new ideas together.</p>
+      <p>
+        A set schedule of
+        <strong class="colorized-magenta">stories, sessions,</strong> and
+        <strong class="colorized-magenta">shared lessons</strong> from people
+        building community-powered tools, services, and networks. It’s a space
+        to share what’s working, reflect on hard-won lessons, and explore new
+        ideas together.
+      </p>
       <div class="cta-buttons">
-      <a role="button" class="outline" href="{{ '/conference' | relative_url }}">See the schedule</a>
+        <a
+          role="button"
+          class="outline"
+          href="{{ '/conference' | relative_url }}"
+          >See the schedule</a
+        >
       </div>
     </article>
     <article>
@@ -128,9 +214,21 @@ redirect_from: /event-overview/
         <h3 class="colorized-orange">The Unconference</h3>
         <p class="colorized-orange">​Sunday, August 17</p>
       </hgroup>
-      <p>A day of <strong class="colorized-orange">workshops</strong> and <strong class="colorized-orange">sessions created by participants</strong>. Anyone can propose a session. Anyone can host. This is where we dive deeper, get hands-on, explore tough questions, and connect around shared interests.</p>
+      <p>
+        A day of <strong class="colorized-orange">workshops</strong> and
+        <strong class="colorized-orange"
+          >sessions created by participants</strong
+        >. Anyone can propose a session. Anyone can host. This is where we dive
+        deeper, get hands-on, explore tough questions, and connect around shared
+        interests.
+      </p>
       <div class="cta-buttons">
-      <a role="button" class="secondary outline" href="{{ '/unconference' | relative_url }}">Read about the unconference</a>
+        <a
+          role="button"
+          class="secondary outline"
+          href="{{ '/unconference' | relative_url }}"
+          >Read about the unconference</a
+        >
       </div>
     </article>
   </div>
@@ -140,10 +238,16 @@ redirect_from: /event-overview/
   <div class="inset-section">
     <h2>Supporters</h2>
     <p>
-      Civic Spark is made possible by the generous support of our sponsors and partners. Their commitment to civic innovation and community building helps us create a space for meaningful connection and collaboration.
+      Civic Spark is made possible by the generous support of our sponsors and
+      partners. Their commitment to civic innovation and community building
+      helps us create a space for meaningful connection and collaboration.
     </p>
     <p>
-      This event is organized by <a href="{{ site.data.links.civictechtoronto }}" target="_blank">Civic Tech Toronto</a> and <a href="{{ site.data.links.one-rg }}" target="_blank">1RG</a>, with support from <a href="{{ site.data.links.carte }}" target="_blank">CARTE</a>.
+      This event is organized by
+      <a href="{{ site.data.links.civictechtoronto }}" target="_blank"
+        >Civic Tech Toronto</a
+      >, <a href="{{ site.data.links.carte }}" target="_blank">CARTE</a>, and
+      <a href="{{ site.data.links.one-rg }}" target="_blank">1RG</a>.
     </p>
   </div>
 </section>

--- a/_pages/sponsors.html
+++ b/_pages/sponsors.html
@@ -1,17 +1,16 @@
 ---
 layout: page
 title: Sponsors
-description: "Civic Spark is made possible by the generous support of our sponsors."
+description: "Civic Spark is made possible by the generous support of our sponsors and organizing partners."
 permalink: /sponsors/
 redirect_from: /sponsors
 hide_sponsors: true
 ---
 
-
 <style>
   .sponsor-logo-container {
     width: 100%;
-    height: 250px;
+    height: 200px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -27,7 +26,7 @@ hide_sponsors: true
     display: block;
   }
 
-  .sponsor-grid{
+  .sponsor-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
@@ -40,42 +39,48 @@ hide_sponsors: true
   }
 </style>
 
-{% assign levels = "presenting_sponsor,major_sponsor,supporting_sponsor,community_partner" | split: "," %}
-{% assign level_names = 
-  "presenting_sponsor:Presenting Partner,major_sponsor:Major Sponsor,supporting_sponsor:Supporting Sponsor,community_partner:Community Partner" 
-  | split: "," | map: "split" | map: "first" | zip: "split:':'|last" %}
+<p>
+  Thank you to all of our partners for helping make Civic Spark possible and for sharing
+  our vision of creating a vibrant, people-centred ecosystem where communities use data,
+  design, and organizing to tackle civic challenges collaboratively, equitably, and
+  creatively.
+</p>
 
-{% for level in levels %}
-  {% assign sponsors_in_level = site.data.sponsors | where: "level", level %}
-  {% if sponsors_in_level.size > 0 %}
-    <h2>
-      {% case level %}
-        {% when "presenting_sponsor" %}Presenting Sponsors
-        {% when "lead_sponsor" %}Lead Sponsors
-        {% when "major_sponsor" %}Major Sponsors
-        {% when "supporting_sponsor" %}Supporting Sponsors
-        {% else %}{{ level | capitalize }}
-      {% endcase %}
-    </h2>
-    <div class="sponsor-list sponsor-grid sponsor-list-{{ level }}">
-      {% for sponsor in sponsors_in_level %}
-        <article class="sponsor-row">
-          <div class="sponsor-logo-container">
-          <img
-            class="sponsor-logo"
-            src="{{ site.baseurl }}/assets/images/sponsors/{{ sponsor.logo }}"
-            alt="{{ sponsor.title }}"
-            style="cursor:pointer"
-            onclick="window.open('{{ sponsor.url }}', '_blank', 'noopener,noreferrer')"
-          />
-          </div>
-          <!-- <div class="sponsor-info">
-            <p class="sponsor-description">{{ sponsor.description }}</p>
-          </div> -->
-        </article>
-      {% endfor %}
+{% assign levels =
+"presenting_sponsor,major_sponsor,supporting_sponsor,community_partner,organizing_partner"
+| split: "," %} {% assign level_names = "presenting_sponsor:Presenting
+Partner,major_sponsor:Major Sponsor,supporting_sponsor:Supporting
+Sponsor,community_partner:Community Partner,organizing_partner:Organizing Partner" |
+split: "," | map: "split" | map: "first" | zip: "split:':'|last" %} {% for level in
+levels %} {% assign sponsors_in_level = site.data.sponsors | where: "level", level %} {%
+if sponsors_in_level.size > 0 %}
+<h2>
+  {% case level %} {% when "presenting_sponsor" %}Presenting Sponsors {% when
+  "lead_sponsor" %}Lead Sponsors {% when "major_sponsor" %}Major Sponsors {% when
+  "supporting_sponsor" %}Supporting Sponsors {% when "organizing_partner" %}Organized
+  and Supported By{% else %}{{ level | capitalize }} {% endcase %}
+</h2>
+<div class="sponsor-list sponsor-grid sponsor-list-{{ level }}">
+  {% for sponsor in sponsors_in_level %}
+  <article class="sponsor-row">
+    <div class="sponsor-logo-container">
+      <img
+        class="sponsor-logo"
+        src="{{ site.baseurl }}/assets/images/sponsors/{{ sponsor.logo }}"
+        alt="{{ sponsor.title }}"
+        style="cursor: pointer"
+        onclick="window.open('{{ sponsor.url }}', '_blank', 'noopener,noreferrer')"
+      />
     </div>
-  {% endif %}
-{% endfor %}
+    <div class="sponsor-info">
+      <div class="sponsor-description">{{ sponsor.description }}</div>
+    </div>
+  </article>
+  {% endfor %}
+</div>
+{% endif %} {% endfor %}
 
-<p>If you're interested in supporting our effort, you can learn more on our <a href="{{'/get-involved/' | relative_url}}">get involved</a> page.
+<p>
+  If you're interested in supporting our effort, you can learn more on our
+  <a href="{{'/get-involved/' | relative_url}}">get involved</a> page.
+</p>


### PR DESCRIPTION
Content changes:

- Added approved blurbs for all sponsors (impacts about and sponsors pages)
- Added organizing partners to sponsor page
- Updated layouts to include blurbs (and slightly reduced height of logo box)
- Changed organizing partners tagline to approved "This event is organized by Civic Tech Toronto, CARTE, and 1RG"

Incidental changes:

- added a Prettier config file - if other users also use the same config then it'll prevent arbitrary git diffs based on formatting
- added redirects for no trailing slash links where they were missing (missing redirect on one of these pages was causing a 404)